### PR TITLE
Add missing #to_h method, needed for non-Rails apps

### DIFF
--- a/lib/visit/request_payload.rb
+++ b/lib/visit/request_payload.rb
@@ -17,6 +17,12 @@ module Visit
       end
     end
 
+    def to_h
+      members.inject({}) do |acc, k|
+        acc.merge(k => send(k))
+      end
+    end
+
     def to_values
       [].tap do |ret|
         [:url, :user_agent, :referer].each do |k|


### PR DESCRIPTION
RequestPayload had some refactoring to split it into RailsRequestContext. The `#to_h` method went with it, yet `Onboarder` expects RequestPayload to implement `#to_h`. I don't think it's possible to use RailsRequestContext for data coming from another app, since it has a hard-dependency on the Rails Request object, which you don't have.
