### PR TITLE
Make error when redis is not configured more obvious

### DIFF
--- a/lib/visit/serialized_list.rb
+++ b/lib/visit/serialized_list.rb
@@ -36,7 +36,11 @@ module Visit
     private
 
     def redis
-      Visit::Configurable.redis
+      if Visit::Configurable.redis.nil?
+        raise "Visit::Connfigurable.redis is not set, please configure it"
+      else
+        Visit::Configurable.redis
+      end
     end
   end
 end


### PR DESCRIPTION
This cost me a bit of time. There's no mention anywhere that Configurable needs a redis instance configuring. If you don't set one, it lazily initializes to nil (which incidentally means the lazy initialization doesn't do anything). Nothing actually checks if it's nil, so it causes a NilClass error, which in development is masked by the rescue block.

This PR just adds a more friendly runtime error to make it easier to debug why it's failing.
