### PR TITLE
Make exception-notifying threadsafe

### DIFF
--- a/lib/visit/onboarder.rb
+++ b/lib/visit/onboarder.rb
@@ -25,7 +25,7 @@ module Visit
 
             list.clear
           end
-        rescue Exception => e
+        rescue => e
           Configurable.notify.call e
         end
       end


### PR DESCRIPTION
Using the global variable `$!` is both difficult to read and not threadsafe. If two of your sidekiq workers error simultaneously for different reasons, the error message each worker reports is unpredictable, due to this global variable.

This commit just uses the local variable binding instead.
