### PR TITLE
Fix the circular reference warning

### DIFF
--- a/lib/visit/has_optimistic_find_or_create.rb
+++ b/lib/visit/has_optimistic_find_or_create.rb
@@ -1,6 +1,6 @@
 module Visit
   module HasOptimisticFindOrCreate
-    def get_id_from_optimistic_find_or_create_by(v: v)
+    def get_id_from_optimistic_find_or_create_by(v: vee)
       raise "unexpected v.nil?" if v.nil?
 
       Configurable.cache.fetch(cache_key_for_v(v)) do
@@ -36,7 +36,7 @@ module Visit
 
     private
 
-    def optimistic_find_or_create_by(v: v)
+    def optimistic_find_or_create_by(v: vee)
       begin
         self.find_or_create_by(v: v)
       rescue ActiveRecord::StatementInvalid => e


### PR DESCRIPTION
We're upgrading Ruby to version 2.2 on SitePoint Premium.

One of the things it introduces is circular reference warnings:
http://blog.vrinek.io/2015/01/15/ruby-2-2/

This commit fixes those warning in this gem.

